### PR TITLE
Fixes the issue where quality is not set correctly

### DIFF
--- a/lib/immagine/image_processor_driver.rb
+++ b/lib/immagine/image_processor_driver.rb
@@ -47,14 +47,16 @@ module Immagine
         image_processor.convert_format!(conversion_format)
       end
 
-      img = image_processor.img
+      img         = image_processor.img
+      img_quality = quality
 
       img.strip!
 
       blob = img.to_blob do
-        self.quality   = quality
+        self.quality   = img_quality
         self.interlace = (img.columns * img.rows <= 100 * 100) ? Magick::NoInterlace : Magick::PlaneInterlace
       end
+
       mime = img.mime_type
 
       [blob, mime]


### PR DESCRIPTION
Within `to_blob` quality did not exist and as a result images were not
being compressed.